### PR TITLE
Add initial skeleton for future work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,95 @@
+# Created by https://www.toptal.com/developers/gitignore/api/java,java-web,netbeans,intellij+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=java,java-web,netbeans,intellij+all
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
 ### Java ###
 # Compiled class file
 *.class
@@ -26,3 +118,19 @@ hs_err_pid*
 ### Java-Web ###
 ## ignoring target file
 target/
+
+### NetBeans ###
+**/nbproject/private/
+**/nbproject/Makefile-*.mk
+**/nbproject/Package-*.bash
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+
+DerbyDB/
+
+config.properties
+
+# End of https://www.toptal.com/developers/gitignore/api/java,java-web,netbeans,intellij+all

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
 Repo documentation should go here in the future, but for now - a placeholder.
+
+### Steps to run in Intellij
+
+1. Clone repo to local directory
+2. Import folder into Intellij
+3. Create run config for glassfish server:
+    1. Download glassfish - I'm using Glassfish 5.1 which seems to work for me
+    2. Add/Edit Configurations
+    3. Add local glassfish server - you may have to click configure and set the path of where you put the glassfish directory.
+    4. Add `domain1` as the domain
+    5. Move to the deployment tab, and add smartcare-web-interface: war-exploded to be deployed
+    6. Edit the update and frame deactivations to your preference, I like update to redeploy classes and resources, and frame deactivation to redeploy resources only.
+    7. The glassfish server should now be deployable.
+
+### Steps to run in Netbeans
+
+1. Clone repo to local directory
+2. Open project (cloned directory) in netbeans
+3. Click Run Project (F6)
+4. Select deployment server (it should prompt you to select one)
+5. It runs like magic (one place where netbeans actually seems to be better)
+
+### Connecting to a database with JDBC 
+Create a file in the `resources` directory called `config.properties`, and then add a line reading:
+    
+    jdbc_database_url=<YOUR_DERBY_DB_URL_HERE>
+
+Here is mine for an example:
+
+    jdbc_database_url=jdbc:derby:C:/Users/tomgo/IdeaProjects/ESD/DerbyDB
+    
+A typical result of getting the URL wrong is "Suitable Driver Not Found".
+The reason you have to add this is so we can all add our own config files seperate of VCS, so merges don't break the URL.
+
+### Gotchas
+
+- I seem to have trouble with the root/source directory config in Intellij if I clone it through Intellij's built in function, it seems to work better to clone it on the command line and then explictly "Open" the cloned directory with the inbuilt `Open...` option under `File`
+- Check your DerbyDB database URL is correct. Should read like: `jdbc_database_url=jdbc:derby:C:/Users/tomgo/IdeaProjects/ESD/DerbyDB`
+- When creating a DerbyDB database instance in Intellij, make sure the directory on the end of the File path you provide DOES NOT EXIST. Else you will get an error but no error message explaining why.
+
+### Git Workflow
+
+1. Make sure local repo is up to date with remote with `git fetch` - some IDEs run this periodically anyway. `git pull` will merge remote changes into your local repo if there are any, `fetch` will just download the data.
+2. Create new local branch with `git checkout -b <branch_name>`. This branch will not be uploaded to GitHub (i.e. remote) until we push it there.
+3. Do some work
+4. Stage your changed files with `git add <file>`, `git add .` will stage all stageable files.
+5. Create a commit with `git commit`. This snapshots the current state of your staged files.
+6. Now you can keep working and continue to create more commits, or you can upload your new work to the remote repo (which in this case is GitHub), by doing `git push`. 
+7. Now you can make a PR (pull request) from your branch to master (our main branch), by using GitHub's PR functionality. If the branch you are targetting has had commits that you do not have on your branch, you will have to rebase your branch onto master. You can do this to your branch locally by doing:
+    ```
+   git fetch origin
+   git rebase origin/master
+   ```
+   Check that your local branch has the desired commits from master by doing `git log` and inspecting the history. When you are satisfied that your branch is good, do a `git push -f` to force push the new history to your remote branch. The PR should now be mergeable without any hairy merge commits.
+   
+8. Some other people should come review your work and hopefully leave some suggestions/comments on what needs to be changed before a merge. Complete this work and push it to your remote branch, and the you can squash these new commits back into the old ones and `git push -f` to keep the history clean.
+9. The PR should then be merged and everybody should be happy

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.smartcare</groupId>
+    <artifactId>web-interface</artifactId>
+    <version>0.1</version>
+    <name>ESD</name>
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <junit.version>5.6.2</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.derby/derby -->
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>10.14.2.0</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/Controllers/GenericServlet.java
+++ b/src/main/java/Controllers/GenericServlet.java
@@ -1,0 +1,24 @@
+package Controllers;
+
+import Utils.Database;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.Connection;
+
+public class GenericServlet extends HttpServlet {
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+    }
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        Connection con = Database.getInstance().getConnection();
+        request.setAttribute("HelloWorld", "Hello World!");
+        request.setAttribute("DatabaseString", con.toString());
+        request.getRequestDispatcher("index.jsp").forward(request, response);
+    }
+}

--- a/src/main/java/Utils/Config.java
+++ b/src/main/java/Utils/Config.java
@@ -1,0 +1,24 @@
+package Utils;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class Config {
+    Properties configFile;
+
+    public Config() {
+        configFile = new Properties();
+        try {
+            InputStream in = getClass().getResourceAsStream("/config.properties");
+            configFile.load(in);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public String getProperty(String key) {
+        return this.configFile.getProperty(key);
+    }
+}

--- a/src/main/java/Utils/Database.java
+++ b/src/main/java/Utils/Database.java
@@ -1,0 +1,37 @@
+package Utils;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Database {
+    private static Database dbInstance;
+    private static Connection con;
+
+    private Database() {
+        // private constructor //
+    }
+
+    public static Database getInstance() {
+        if (dbInstance == null) {
+            dbInstance = new Database();
+        }
+        return dbInstance;
+    }
+
+    public Connection getConnection() {
+        Config cfg = new Config();
+        if (con == null) {
+            try {
+                String host = cfg.getProperty("jdbc_database_url");
+                con = DriverManager.getConnection(host);
+            } catch (SQLException ex) {
+                Logger.getLogger(Database.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+
+        return con;
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+    <servlet>
+        <servlet-name>GenericServlet</servlet-name>
+        <servlet-class>Controllers.GenericServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>GenericServlet</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,0 +1,17 @@
+<%--
+  Created by IntelliJ IDEA.
+  User: tomgo
+  Date: 20/11/2020
+  Time: 19:27
+  To change this template use File | Settings | File Templates.
+--%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+    <h1>All good!</h1>
+    Database String: ${requestScope.DatabaseString}
+</body>
+</html>


### PR DESCRIPTION
I've tested this on Intellij and Netbeans and it seems to work in both for me - you just need to set up the database and deployment server (glassfish) using their respective methods. I've added some guides to the README to help people get it working if it isn't working, plus a brief overview of the Git workflow you'll be using most often.

I've added a config file class that reads a file 'config.properties' from the resources folder. You will need to add your JDBC URL there, as specified in the README.

The result should be a skeleton framework with a working JDBC connection deployed to glassfish.

Have a readthrough to see if I've missed anything.