### PR TITLE
Link CSS in new JSP's

### DIFF
--- a/src/main/webapp/AppointmentPages.jsp
+++ b/src/main/webapp/AppointmentPages.jsp
@@ -10,6 +10,9 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=PT+Sans&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="${pageContext.request.contextPath}/styles/main.css" />
         <title>JSP Page</title>
     </head>
     <body>

--- a/src/main/webapp/IssuePrescription.jsp
+++ b/src/main/webapp/IssuePrescription.jsp
@@ -9,6 +9,9 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=PT+Sans&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="${pageContext.request.contextPath}/styles/main.css" />
         <title>Issue Prescription Form</title>
     </head>
     <body>

--- a/src/main/webapp/dashboards/admin.jsp
+++ b/src/main/webapp/dashboards/admin.jsp
@@ -9,6 +9,9 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <html>
 <head>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=PT+Sans&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/styles/main.css" />
     <title>Admin Page</title>
 </head>
 <body>

--- a/src/main/webapp/dashboards/patient.jsp
+++ b/src/main/webapp/dashboards/patient.jsp
@@ -8,6 +8,9 @@
 <%@ page contentType="text/html;charset=UTF-8"%>
 <html>
 <head>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=PT+Sans&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/styles/main.css" />
     <title>Patient Dashboard</title>
 </head>
 <body>

--- a/src/main/webapp/dashboards/staff.jsp
+++ b/src/main/webapp/dashboards/staff.jsp
@@ -8,6 +8,9 @@
 <%@ page contentType="text/html;charset=UTF-8"%>
 <html>
 <head>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=PT+Sans&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/styles/main.css" />
     <title>Staff Dashboard</title>
 </head>
 <body>

--- a/src/main/webapp/login.jsp
+++ b/src/main/webapp/login.jsp
@@ -9,7 +9,7 @@
 <head>
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=PT+Sans&display=swap" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="styles/main.css" />
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/styles/main.css" />
     <title>Login</title>
 </head>
 <body>

--- a/src/main/webapp/register.jsp
+++ b/src/main/webapp/register.jsp
@@ -9,7 +9,7 @@
 <head>
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=PT+Sans&display=swap" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="styles/main.css" />
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/styles/main.css" />
     <title>Register</title>
 </head>
 <body>


### PR DESCRIPTION
Young and dumb PR to link the CSS in the new JSP's.

In testing, all CSS is currently broken by the introduction of the `/*` in the web.xml LoginFilter URLPattern. This isn't exactly a priority so I think we should investigate next sprint.